### PR TITLE
Add Content-Length check and retry for truncated downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__
 .pytest_cache
 .vscode
 cvdupdate.egg-info
+/build
+/dist


### PR DESCRIPTION
This is to address Issue #3 where a flaky proxy connection resulted in
partial downloads. This fix is to retry up to 3x if the downloaded
content is less than the advertised Content-Length (if the header
exists, it may not for downloads from other places, like Github for
example).

Also fixed a couple issues with testing `cvd update <specific database>`
for testing a non-official download from Github.