### PR TITLE
Change the User-Agent to something unique

### DIFF
--- a/cvdupdate/__main__.py
+++ b/cvdupdate/__main__.py
@@ -91,13 +91,14 @@ def db_show(config: str, verbose: bool, db: str):
 @cli.command("update")
 @click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
 @click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
+@click.option("--debug-mode", "-D", is_flag=True, default=False, help="Print out HTTP headers for debugging purposes. [optional]")
 @click.argument("db", required=False, default="")
-def db_update(config: str, verbose: bool, db: str):
+def db_update(config: str, verbose: bool, db: str, debug_mode: bool):
     """
     Update the DBs from the internet. Will update all DBs if DB not specified.
     """
     m = CVDUpdate(config=config, verbose=verbose)
-    errors = m.db_update(db)
+    errors = m.db_update(db, debug_mode)
     if errors > 0:
         sys.exit(errors)
 
@@ -247,8 +248,9 @@ def show_alias(ctx, config: str, verbose: bool, db: str):
 @click.pass_context
 @click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
 @click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
+@click.option("--debug-mode", "-D", is_flag=True, default=False, help="Print out HTTP headers for debugging purposes. [optional]")
 @click.argument("db", required=False, default="")
-def update_alias(ctx, config: str, verbose: bool, db: str):
+def update_alias(ctx, config: str, verbose: bool, db: str, debug_mode: bool):
     """
     Update local copy of DBs.
 


### PR DESCRIPTION
We'll allow this new User-Agent format for CVD updates.
Added a randomly generated UUID to the User-Agent for better (anonymous)
metrics.

Also added a --debug-mode (-D) option for `cvd update` command to
validate the HTTP headers sent & received are as expected.

This PR is blocked until the new User-Agent is allowed by the CDN.

The agent will look something like: 
  `User-Agent: CVDUPDATE/0.2.0 (81c94618-924e-4746-86ba-7654085baf40)`